### PR TITLE
Fix example in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,9 +88,11 @@ reader.on('discard', function(msg){
 
 var writer = nsq.writer(':4150');
 
-writer.publish('events', 'foo');
-writer.publish('events', 'bar');
-writer.publish('events', 'baz');
+writer.on('ready', function() {
+  writer.publish('events', 'foo');
+  writer.publish('events', 'bar');
+  writer.publish('events', 'baz');
+});
 ```
 
 ## API


### PR DESCRIPTION
The current hello world example in the README does not work.
I fixed it by having the writer wait for the `ready` event.
