### PR TITLE
fix multiple callbacks when socket errors occur

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -529,7 +529,9 @@ function hasSuccessResponse(name) {
 
 function error(err, fns) {
   debug('broadcast error to %d functions', fns.length);
-  fns.forEach(function(fn){
+  // pop them off the queue in order and make
+  // sure they are called only once
+  for (var fn; fn = fns.shift();) {
     fn(err);
-  });
+  }
 }

--- a/test/acceptance/connection.js
+++ b/test/acceptance/connection.js
@@ -57,4 +57,21 @@ describe('Connection', function(){
 
     conn.connect();
   })
+
+  it('should only call callbacks a single time', function(done){
+    var conn = new Connection;
+    var called = 0;
+
+    conn.on('error', function(){});
+    conn.on('ready', function(){
+      conn.sock.destroy();
+      conn.publish('test', 'something', function(err){
+        called++;
+      });
+      assert.equal(called, 1);
+      done();
+    });
+
+    conn.connect();
+  })
 })


### PR DESCRIPTION
Realized there might be a case where the socket errors on a write,
and then there are multiple write calls. Each write will emit an
error, causing multiple callbacks for things like publish
