### PR TITLE
remove old connections using lookupd

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -117,12 +117,15 @@ Reader.prototype.poll = function(ms){
   setInterval(function(){
     self.lookup(function(err, nodes){
       if (err) return self.emit('error', err);
-      nodes.map(address).forEach(function(addr){
-        if (self.connected[addr]) {
-          debug('already connected to %s', addr);
-        } else {
-          self.connectTo(addr);
-        }
+      var addrs = nodes.map(address);
+      addrs.forEach(function(addr){
+        if (self.connected[addr]) return debug('already connected to %s', addr);
+        self.connectTo(addr);
+      });
+
+      self.conns.each(function(conn){
+        if (~addrs.indexOf(conn.addr)) return;
+        self.remove(conn);
       });
     });
   }, ms);
@@ -210,6 +213,21 @@ Reader.prototype.connectTo = function(addr){
   this.conns.add(conn);
   this.distributeMaxInFlight();
 };
+
+/**
+ * Remove a `conn` from the connected set.
+ *
+ * @param {Connection} con
+ * @api private
+ */
+
+Reader.prototype.remove = function(conn){
+  debug('removing connection %s', conn.addr);
+  this.connected[conn.addr] = false;
+  this.conns.remove(conn);
+  conn.removeAllListeners();
+  conn.destroy();
+}
 
 /**
  * Delegate events from `conn`.


### PR DESCRIPTION
This commit removes old connections when they are no longer
returned from the lookupd.

Alternatively we could lower the maxConnectionAttempts
for our nodes internally.

@visionmedia @gjohnson 
