### PR TITLE
Add optional client_id to the identify

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -43,6 +43,7 @@ module.exports = Connection;
 function Connection(opts) {
   opts = opts || {};
   this.trace = opts.trace || function(){};
+  this.id = opts.id;
   this.port = opts.port || 4150;
   this.host = opts.host || '0.0.0.0';
   this.addr = this.host + ':' + this.port;
@@ -111,7 +112,8 @@ Connection.prototype.connect = function(fn){
     short_id: host.split('.')[0],
     long_id: host,
     user_agent: this.ua,
-    msg_timeout: opts.msgTimeout
+    msg_timeout: opts.msgTimeout,
+    client_id: this.id
   };
 
   this.sock.write('  V' + this.version);

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -35,6 +35,7 @@ module.exports = Reader;
  * - `ready` when `false` auto-RDY maintenance will be disabled
  * - `trace` optional trace function
  * - `maxConnectionAttempts` max reconnection attempts [Infinity]
+ * - `id` client identifier
  *
  * The Reader is in charge of establishing connections
  * between the given `nsqd` nodes, or looking them
@@ -63,6 +64,7 @@ function Reader(opts) {
   this.autoready = opts.ready;
   this.topic = opts.topic;
   this.nsqd = opts.nsqd;
+  this.id = opts.id;
   this.connected = {};
   this.conns = new Set;
 
@@ -191,7 +193,8 @@ Reader.prototype.connectTo = function(addr){
     msgTimeout: msgTimeout,
     trace: this.trace,
     host: addr.host,
-    port: addr.port
+    port: addr.port,
+    id: this.id
   });
 
   // apply reconnection


### PR DESCRIPTION
Adds an optional `client_id` to the "identity" by exposing a new `id` option to readers ([see spec](http://nsq.io/clients/tcp_protocol_spec.html#identify)).

``` js
var reader = nsq.reader({ id: 'my-worker' });
```

Nice little benefit of this is that you can get a littttttle better idea of who is who in the admin, when multiple consumers are running on a single host. See before and after:

**Before**

![no-client-id](https://cloud.githubusercontent.com/assets/67717/3978775/61000904-284c-11e4-9d33-915959c10bae.jpg)

**After**

![client-id](https://cloud.githubusercontent.com/assets/67717/3978777/67e84a38-284c-11e4-8931-790458503c26.jpg)

cc: @visionmedia 
