### PR TITLE
Add callback to writer close

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -418,9 +418,10 @@ Connection.prototype.resume = function(){
  * @api private
  */
 
-Connection.prototype.end = function(){
+Connection.prototype.end = function(fn){
   debug('%s - end', this.addr);
   this.closing = true;
+  if (fn) this.sock.once('end', fn);
   this.sock.end();
 };
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -182,9 +182,12 @@ Writer.prototype.connectTo = function(addr){
  * @api public
  */
 
-Writer.prototype.close = function(){
+Writer.prototype.close = function(fn){
+  var n = this.conns.size();
   this.conns.each(function(conn){
-    conn.end();
+    conn.end(function(){
+      if (fn) --n || fn();
+    });
   });
 };
 

--- a/test/acceptance/writer.js
+++ b/test/acceptance/writer.js
@@ -57,6 +57,37 @@ describe('Writer#publish()', function(){
     pub.on('error', function(){});
   })
 
+  it('should close with an optional callback', function(done){
+    var pub = nsq.writer();
+    var sub = new Connection;
+    var n = 0;
+
+    function next(err){
+      if (err) return done(err);
+      n = n + 1;
+    }
+
+    pub.on('ready', function(){
+      pub.publish('test', new Buffer(1024), next);
+      pub.publish('test', new Buffer(1024), next);
+      pub.publish('test', new Buffer(1024), next);
+      pub.close(function(){
+        assert(n === 3);
+        done();
+      });
+    });
+
+    sub.on('ready', function(){
+      sub.subscribe('test', 'tailer');
+    });
+
+    sub.on('message', function(msg){
+      msg.finish();
+    });
+
+    sub.connect();
+  });
+
   describe('with an array', function(){
     it('should MPUT', function(done){
       var pub = nsq.writer();


### PR DESCRIPTION
I'm relying on [net.Socket's close event](http://nodejs.org/api/net.html#net_event_close_1) to ensure all IO is flushed rather than keeping count of messages PUB-ed that have not received a response yet. Should be good enough...

NOTE: this does not add a callback to Connection#destroy because destroying implies you don't care about outgoing data.
