### PR TITLE
Don't reconnect via poll() on close

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -67,6 +67,7 @@ function Reader(opts) {
   this.id = opts.id;
   this.connected = {};
   this.conns = new Set;
+  this.timer = null;
 
   // mixins
   close(this);
@@ -116,7 +117,8 @@ Reader.prototype.poll = function(ms){
   var self = this;
 
   debug('polling every %dms', ms);
-  setInterval(function(){
+  var timer = setInterval(function(){
+    if (self.closing) return;
     self.lookup(function(err, nodes){
       if (err) return self.emit('error', err);
       var addrs = nodes.map(address);
@@ -124,7 +126,6 @@ Reader.prototype.poll = function(ms){
         if (self.connected[addr]) return debug('already connected to %s', addr);
         self.connectTo(addr);
       });
-
       self.conns.each(function(conn){
         if (~addrs.indexOf(conn.addr)) return;
         self.remove(conn);
@@ -317,6 +318,8 @@ Reader.prototype.resume = function(){
 Reader.prototype.close = function(fn){
   debug('close');
   if (fn) this.once('close', fn);
+  clearInterval(this.timer);
+  this.closing = true;
   this.conns.each(function(conn){
     conn.close();
   });

--- a/test/acceptance/connection.js
+++ b/test/acceptance/connection.js
@@ -16,9 +16,9 @@ describe('Connection', function(){
     conn.connect();
 
     conn.on('ready', function(){
-      assert(conn.features.version);
-      assert(conn.features.max_rdy_count);
-      assert(conn.features.msg_timeout);
+      assert('version' in conn.features);
+      assert('max_rdy_count' in conn.features);
+      assert('msg_timeout' in conn.features);
       done();
     });
   })


### PR DESCRIPTION
This prevents the lookupd polling from connecting after a close as occurred, which may lead to dropped events.
