### PR TITLE
connection: fix socket errors after destroy

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -466,6 +466,7 @@ Connection.prototype.end = function(fn){
 
 Connection.prototype.destroy = function(){
   debug('destroy');
+  this.sock.emit = function(){};
   this.sock.destroy();
 };
 

--- a/test/acceptance/connection.js
+++ b/test/acceptance/connection.js
@@ -74,4 +74,15 @@ describe('Connection', function(){
 
     conn.connect();
   })
+
+  it('should not emit socket errors after destroy', function(done){
+    var conn = new Connection;
+    conn.on('error', done);
+    conn.on('ready', function(){
+      conn.destroy();
+      conn.sock.emit('error', new Error);
+      done();
+    });
+    conn.connect();
+  })
 })


### PR DESCRIPTION
This fixes https://github.com/segmentio/nsq.js/issues/54

I'll also look whether this is an issue to be adressed to node/iojs, since the socket emits an error event after `sock.destroy()` has been called