### PR TITLE
conn: ignore all writes after the socket is closed

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -137,6 +137,12 @@ Connection.prototype.command = function(name, args, data, fn){
   var sock = this.sock;
   var chunks = [];
 
+  // socket closed
+  if (this.closed) {
+    debug('%s - ignoring %s socket was closed', this.addr, name);
+    return;
+  }
+
   // callback
   if ('function' == typeof data) {
     fn = data;
@@ -246,7 +252,7 @@ Connection.prototype.onframe = function(frame){
         msg.finish();
         this.emit('discard', msg);
         return;
-      } 
+      }
       this.emit('message', msg);
       break;
   }
@@ -449,6 +455,7 @@ Connection.prototype.end = function(fn){
   debug('%s - end', this.addr);
   this.closing = true;
   if (fn) this.sock.once('end', fn);
+  this.closed = true;
   this.sock.end();
 };
 

--- a/test/acceptance/connection.js
+++ b/test/acceptance/connection.js
@@ -85,4 +85,15 @@ describe('Connection', function(){
     });
     conn.connect();
   })
+
+  it('should not write after socket.end()', function(done){
+    var conn = new Connection;
+    conn.connect();
+    conn.on('ready', function(){
+      conn.end();
+      conn.publish('test', 'stuff');
+      conn.on('error', done);
+      conn.on('end', done);
+    });
+  });
 })


### PR DESCRIPTION
this _should_ fix the `write after end` errors we are seeing.

cc @gjohnson 