### PR TITLE
bump bignum package for node 4.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "backo": "~1.0.1",
-    "bignum": "~0.9.0",
+    "bignum": "~0.11.0",
     "debug": "~0.7.4",
     "ms": "~0.6.2",
     "node-int64": "~0.3.0",


### PR DESCRIPTION
bignum@0.9.0 fails to build on node 4. 0.11.0 has updated nan and successfully builds against node 4