### PR TITLE
updating bignum

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "backo": "~1.0.1",
-    "bignum": "~0.9.0",
+    "bignum": "~0.11.0",
     "debug": "~0.7.4",
     "ms": "~0.6.2",
     "node-int64": "~0.3.0",


### PR DESCRIPTION
updating bignum to the newest version so it can be compiled by node 4.1

cc @gjohnson 