### PR TITLE
Wait for a connection on publish

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,11 +88,9 @@ reader.on('discard', function(msg){
 
 var writer = nsq.writer(':4150');
 
-writer.on('ready', function() {
-  writer.publish('events', 'foo');
-  writer.publish('events', 'bar');
-  writer.publish('events', 'baz');
-});
+writer.publish('events', 'foo');
+writer.publish('events', 'bar');
+writer.publish('events', 'baz');
 ```
 
 ## API
@@ -137,7 +135,8 @@ Events:
 
  Publish the given `message` to `topic` where `message`
  may be a string, buffer, or object. An array of messages
- may be passed, in which case a MPUT is performed.
+ may be passed, in which case a MPUT is performed.  It will 
+ wait for a connection to be established.
 
 ### writer#close([fn])
 Close the writer's connection(s) and fire the optional [fn] when completed.

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -58,18 +58,27 @@ Writer.prototype.publish = function(topic, msg, fn){
     msg = coerce(msg);
   }
 
-  // connection pool
   var size = this.conns.size();
-  var i = this.n++ % size;
-  var conn = this.conns.values()[i];
-  if (!conn) return fn(new Error('no nsqd nodes connected'));
 
-  // publish
-  debug('%s - publish', conn.addr);
-  if (Array.isArray(msg)) {
-    conn.mpublish(topic, msg, fn);
+  if (size) {
+    // connection pool
+    var i = this.n++ % size;
+    var conn = this.conns.values()[i];
+
+    // publish
+    debug('%s - publish', conn.addr);
+    if (Array.isArray(msg)) {
+      conn.mpublish(topic, msg, fn);
+    } else {
+      conn.publish(topic, msg, fn);
+    }
   } else {
-    conn.publish(topic, msg, fn);
+    // wait for ready and retry
+    var self = this;
+
+    this.once('ready', function(){
+      self.publish(topic, msg, fn)
+    });
   }
 };
 

--- a/test/acceptance/writer.js
+++ b/test/acceptance/writer.js
@@ -15,9 +15,7 @@ describe('Writer#publish()', function(){
     var pub = nsq.writer();
     var sub = new Connection;
 
-    pub.on('ready', function(){
-      pub.publish('test', 'something');
-    });
+    pub.publish('test', 'something');
 
     sub.on('ready', function(){
       sub.subscribe('test', 'tailer');
@@ -30,17 +28,6 @@ describe('Writer#publish()', function(){
     });
 
     sub.connect();
-  })
-
-  it('should invoke callbacks with errors', function(done){
-    var pub = nsq.writer({ port: 5000 });
-
-    pub.on('error', function(){});
-
-    pub.publish('test', 'something', function(err){
-      err.message.should.equal('no nsqd nodes connected');
-      done();
-    });
   })
 
   it('should emit "error"', function(done){


### PR DESCRIPTION
This PR mimics the same behaviour of [nsqjs](https://github.com/dudleycarr/nsqjs) when `writer.publish()` is called and the connection is not established.

Reference: https://github.com/dudleycarr/nsqjs/blob/master/src/writer.coffee#L92