### PR TITLE
Fixes uncatchable error

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -244,6 +244,7 @@ Reader.prototype.remove = function(conn){
   this.connected[conn.addr] = false;
   this.conns.remove(conn);
   conn.removeAllListeners();
+  conn.emit = function(){};
   conn.destroy();
 }
 


### PR DESCRIPTION
Shouldn't emit error after it is destroyed. Basically if it cannot connect to the nsqd or nsqlooupd instances it removes the connections, removesAllListeners, then destroys it and then emits an error making it uncatchable.
